### PR TITLE
optimize with throttle and only scope.apply when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mm-on-enter-viewport",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Directive to detect when an element has entered the viewport",
   "scripts": {
     "build-standalone": "npm run lint && webpack --progress --colors && gulp docs",
@@ -18,7 +18,8 @@
   "main": "out/index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "babel-runtime": "^5.6.17"
+    "babel-runtime": "^5.6.17",
+    "lodash" : "^2.4.1"
   },
   "peerDependencies": {
     "angular": "^1.3.0"


### PR DESCRIPTION
This should help performance when there are many on-enter-viewport directives used